### PR TITLE
Bump UnCSS version to 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
         "email": "jakub@burkiewicz.eu"
     },
     "dependencies": {
-        "uncss": "~0.7.9"
+        "uncss": "~0.12.1"
     }
 }


### PR DESCRIPTION
This plugin is using quite an older version of UnCSS. Bumped it to latest, which still uses the same options hash so requires no change afaics.